### PR TITLE
홈 캘린더 레이아웃 스크롤 제거 및 iOS 환경 최적화

### DIFF
--- a/components/calendar/PikuCalendar.tsx
+++ b/components/calendar/PikuCalendar.tsx
@@ -61,15 +61,15 @@ const PikuCalendar = ({
   };
 
   return (
-    <main {...handlers} className="flex-grow flex flex-col p-2">
-      <div className="grid grid-cols-7 text-center text-sm text-gray-500 dark:text-gray-400">
+    <main {...handlers} className="flex-1 flex flex-col p-2 min-h-0 overflow-hidden">
+      <div className="grid grid-cols-7 text-center text-sm text-gray-500 dark:text-gray-400 flex-shrink-0">
         {dayNames.map(day => (
           <div key={day} className="py-2">
             {day}
           </div>
         ))}
       </div>
-      <div className="grid grid-cols-7 flex-grow gap-1">
+      <div className="grid grid-cols-7 flex-1 gap-1 min-h-0">
         {days.map((day, index) => {
           const dateKey = format(day, 'yyyy-MM-dd');
           const pikuData = pikus[dateKey];

--- a/components/common/BottomNav.tsx
+++ b/components/common/BottomNav.tsx
@@ -115,13 +115,13 @@ const BottomNav = () => {
 
   // PWA를 사용하는 iOS 모바일에서 BottomNav 스타일 조정
   const getBottomNavClass = () => {
-    let baseClass = "flex justify-around items-center border-t xl:hidden sticky bottom-0 bg-white z-10";
+    let baseClass = "flex justify-around items-center border-t xl:hidden bg-white dark:bg-black fixed bottom-0 left-0 right-0 z-20";
     
     if (isPWAiOS && isMobile) {
       // PWA를 사용하는 iOS에서 크기 증가 및 safe area 고려
-      return `${baseClass} p-4 pb-6 min-h-[80px]`;
+      return `${baseClass} p-4 pt-2 min-h-[80px]`;
     }
-    return `${baseClass} p-2`;
+    return `${baseClass} p-2 pt-2`;
   };
 
   // PWA를 사용하는 iOS 모바일에서 아이콘 크기 조정
@@ -154,8 +154,11 @@ const BottomNav = () => {
         .animate-slide-up {
           animation: slide-up 0.25s ease-out;
         }
+        .bottom-nav {
+          padding-bottom: calc(0.5rem + env(safe-area-inset-bottom));
+        }
       `}</style>
-      <footer className={getBottomNavClass()}>
+      <footer className={`${getBottomNavClass()} bottom-nav`}>
         <Link href="/" className={getLinkClass('/')}>
           <Home className={getIconSize()} />
           <span className={getTextSize()}>홈</span>

--- a/components/common/GuestBottomNav.tsx
+++ b/components/common/GuestBottomNav.tsx
@@ -76,13 +76,13 @@ const GuestBottomNav = () => {
 
   // PWA를 사용하는 iOS 모바일에서 BottomNav 스타일 조정
   const getBottomNavClass = () => {
-    let baseClass = "flex justify-around items-center border-t xl:hidden sticky bottom-0 bg-white z-10";
+    let baseClass = "flex justify-around items-center border-t xl:hidden bg-white dark:bg-black fixed bottom-0 left-0 right-0 z-20";
     
     if (isPWAiOS && isMobile) {
       // PWA를 사용하는 iOS에서 크기 증가 및 safe area 고려
-      return `${baseClass} p-4 pb-6 min-h-[80px]`;
+      return `${baseClass} p-4 pt-2 min-h-[80px]`;
     }
-    return `${baseClass} p-2`;
+    return `${baseClass} p-2 pt-2`;
   };
 
   // PWA를 사용하는 iOS 모바일에서 아이콘 크기 조정
@@ -115,8 +115,11 @@ const GuestBottomNav = () => {
         .animate-slide-up {
           animation: slide-up 0.25s ease-out;
         }
+        .bottom-nav {
+          padding-bottom: calc(0.5rem + env(safe-area-inset-bottom));
+        }
       `}</style>
-      <footer className={getBottomNavClass()}>
+      <footer className={`${getBottomNavClass()} bottom-nav`}>
         <Link href="/" className={getLinkClass('/')}>
           <Compass className={getIconSize()} />
           <span className={getTextSize()}>홈</span>

--- a/components/common/LayoutWrapper.tsx
+++ b/components/common/LayoutWrapper.tsx
@@ -52,19 +52,37 @@ const LayoutWrapper = ({ children }: { children: React.ReactNode }) => {
   }
 
   return (
-    <div className="flex flex-col min-h-screen">
-      {isLoggedIn && <FCMInitializer />}
-      {isLoggedIn && <SSEInitializer />}
-      <MobileHeader />
-      <div className="flex flex-1">
-        {isLoggedIn ? <Sidebar /> : <GuestSidebar />}
-        <main className="w-full pt-14 xl:ml-64 transition-all duration-300 md:grid md:grid-cols-8 md:gap-4 xl:pt-0">
-          <div className="md:col-span-4 md:col-start-3 h-full">{children}</div>
-        </main>
+    <>
+      <style jsx global>{`
+        .layout-container {
+          height: 100vh;
+          height: 100dvh; /* iOS Safari를 위한 동적 뷰포트 높이 */
+        }
+        
+        .main-content-wrapper {
+          padding-bottom: calc(3.5rem + env(safe-area-inset-bottom));
+        }
+        
+        @media (min-width: 1280px) {
+          .main-content-wrapper {
+            padding-bottom: 0;
+          }
+        }
+      `}</style>
+      <div className="flex flex-col overflow-hidden layout-container">
+        {isLoggedIn && <FCMInitializer />}
+        {isLoggedIn && <SSEInitializer />}
+        <MobileHeader />
+        <div className="flex flex-1 overflow-hidden pt-14 xl:pt-0 main-content-wrapper">
+          {isLoggedIn ? <Sidebar /> : <GuestSidebar />}
+          <main className="w-full flex-1 xl:ml-64 transition-all duration-300 md:grid md:grid-cols-8 md:gap-4 overflow-hidden">
+            <div className="md:col-span-4 md:col-start-3 h-full overflow-hidden">{children}</div>
+          </main>
+        </div>
+        {isLoggedIn ? <BottomNav /> : <GuestBottomNav />}
+        <PWAInstallPrompt />
       </div>
-      {isLoggedIn ? <BottomNav /> : <GuestBottomNav />}
-      <PWAInstallPrompt />
-    </div>
+    </>
   );
 };
 

--- a/components/home/HomeCalendar.tsx
+++ b/components/home/HomeCalendar.tsx
@@ -147,13 +147,13 @@ const HomeCalendar = ({
 
   return (
     <div
-      className="flex flex-col overflow-hidden xl:pb-0 h-full"
+      className="flex flex-col h-full overflow-hidden"
       ref={containerRef}
     >
       <AnimatePresence initial={false} custom={direction}>
         <motion.div
           key={viewedUser ? viewedUser.userId : user.id}
-          className="h-full flex flex-col"
+          className="h-full flex flex-col overflow-hidden"
           variants={slideVariants}
           custom={direction}
           initial="initial"

--- a/components/home/HomeCalendarHeader.tsx
+++ b/components/home/HomeCalendarHeader.tsx
@@ -26,7 +26,7 @@ const HomeCalendarHeader = ({
   onDateChange,
 }: HomeCalendarHeaderProps) => {
   return (
-    <div className="space-y-4 p-4 md:p-6">
+    <div className="space-y-4 p-4 md:p-6 flex-shrink-0">
       {/* <div className="flex items-center justify-between md:hidden">
         <h1 className="text-2xl font-bold">PikUme</h1>
       </div> */}


### PR DESCRIPTION
- 전체 화면 높이에서 헤더와 바텀 네비게이션을 제외한 영역에 달력이 스크롤 없이 딱 맞게 표시되도록 레이아웃 구조 개선
- iOS Safari의 동적 뷰포트 높이(100dvh) 및 safe area 지원 추가