### PR TITLE
피드 스켈레톤 UI 적용 및 로딩 정합성 개선

### DIFF
--- a/app/feed/page.test.tsx
+++ b/app/feed/page.test.tsx
@@ -12,7 +12,12 @@ describe('FeedPage', () => {
   it('피드 클라이언트가 준비되는 동안 카드 스켈레톤 2개를 표시한다', () => {
     render(<FeedPage />);
 
+    const loadingStatus = screen.getByRole('status', {
+      name: '피드를 불러오는 중',
+    });
+
     expect(screen.getAllByTestId('feed-skeleton-card')).toHaveLength(2);
+    expect(loadingStatus.parentElement).toHaveClass('xl:pt-[73px]');
     expect(screen.queryByText('피드를 불러오는 중...')).not.toBeInTheDocument();
   });
 });

--- a/app/feed/page.test.tsx
+++ b/app/feed/page.test.tsx
@@ -17,7 +17,9 @@ describe('FeedPage', () => {
     });
 
     expect(screen.getAllByTestId('feed-skeleton-card')).toHaveLength(2);
-    expect(loadingStatus.parentElement).toHaveClass('xl:pt-[73px]');
+    expect(loadingStatus.parentElement).toHaveClass(
+      'xl:pt-[calc(4.5rem+1px)]',
+    );
     expect(screen.queryByText('피드를 불러오는 중...')).not.toBeInTheDocument();
   });
 });

--- a/app/feed/page.test.tsx
+++ b/app/feed/page.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import FeedPage from './page';
+
+vi.mock('@/components/feed/FeedClient', () => ({
+  default: () => {
+    throw new Promise(() => {});
+  },
+}));
+
+describe('FeedPage', () => {
+  it('피드 클라이언트가 준비되는 동안 카드 스켈레톤 2개를 표시한다', () => {
+    render(<FeedPage />);
+
+    expect(screen.getAllByTestId('feed-skeleton-card')).toHaveLength(2);
+    expect(screen.queryByText('피드를 불러오는 중...')).not.toBeInTheDocument();
+  });
+});

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -17,7 +17,7 @@ const FeedPage = () => {
     <div className="w-full">
       <Suspense
         fallback={
-          <div className="mx-auto max-w-[600px] pt-[3.75rem] xl:pt-[73px]">
+          <div className="mx-auto max-w-[600px] pt-[3.75rem] xl:pt-[calc(4.5rem+1px)]">
             <FeedSkeleton count={2} />
           </div>
         }

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,4 +1,5 @@
 import FeedClient from '@/components/feed/FeedClient';
+import FeedSkeleton from '@/components/feed/FeedSkeleton';
 import { createPageMetadata } from '@/lib/metadata/createPageMetadata';
 import { Suspense } from 'react';
 
@@ -16,8 +17,8 @@ const FeedPage = () => {
     <div className="w-full">
       <Suspense
         fallback={
-          <div className="flex h-full w-full items-center justify-center pt-20">
-            피드를 불러오는 중...
+          <div className="mx-auto max-w-[600px] pt-[3.75rem] xl:pt-0">
+            <FeedSkeleton count={2} />
           </div>
         }
       >

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -17,7 +17,7 @@ const FeedPage = () => {
     <div className="w-full">
       <Suspense
         fallback={
-          <div className="mx-auto max-w-[600px] pt-[3.75rem] xl:pt-0">
+          <div className="mx-auto max-w-[600px] pt-[3.75rem] xl:pt-[73px]">
             <FeedSkeleton count={2} />
           </div>
         }

--- a/components/feed/FeedCard.tsx
+++ b/components/feed/FeedCard.tsx
@@ -232,7 +232,10 @@ const FeedCard = ({
   return (
     <>
       {/* <div className="w-full rounded-lg border bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800"> */}
-      <div className="w-full rounded-xl border border-gray-200 bg-white shadow-md p-4 dark:border-gray-700 dark:bg-gray-800">
+      <div
+        data-testid="feed-card"
+        className="w-full rounded-xl border border-gray-200 bg-white shadow-md p-4 dark:border-gray-700 dark:bg-gray-800"
+      >
         <div className="flex items-center justify-between p-3">
           <div className="relative flex items-center">
             {isAnonymousPost || !post.userId ? (

--- a/components/feed/FeedClient.tsx
+++ b/components/feed/FeedClient.tsx
@@ -28,6 +28,7 @@ const FeedClient = () => {
   const [error, setError] = useState<'initial' | 'next' | null>(null);
   const [selectedSort, setSelectedSort] = useState<FeedSortMode>('latest');
   const activeSortRef = useRef<FeedSortMode>('latest');
+  const requestGenerationRef = useRef(0);
   const observer = useRef<IntersectionObserver | null>(null);
   const hasMounted = useRef(false);
   const hasDetailHistoryEntryRef = useRef(false);
@@ -230,12 +231,13 @@ const FeedClient = () => {
 
   const loadMore = useCallback(async () => {
     if (loading || !hasMore) return;
+    const requestGeneration = ++requestGenerationRef.current;
     setLoading(true);
     setError(null);
     const sortAtStart = activeSortRef.current;
     try {
       const data = await getFeedCursor(nextCursor, 20, sortAtStart);
-      if (activeSortRef.current !== sortAtStart) return;
+      if (requestGeneration !== requestGenerationRef.current) return;
       setFeed(prevFeed => {
         const existingIds = new Set(prevFeed.map(p => p.diaryId));
         const uniqueNewItems = data.items.filter(
@@ -246,11 +248,11 @@ const FeedClient = () => {
       setNextCursor(data.nextCursor);
       setHasMore(data.nextCursor != null && data.hasNext);
     } catch (err) {
-      if (activeSortRef.current !== sortAtStart) return;
+      if (requestGeneration !== requestGenerationRef.current) return;
       console.error('Error fetching feed:', err);
       setError(feedLengthRef.current === 0 ? 'initial' : 'next');
     } finally {
-      if (activeSortRef.current === sortAtStart) {
+      if (requestGeneration === requestGenerationRef.current) {
         setLoading(false);
       }
     }
@@ -283,6 +285,7 @@ const FeedClient = () => {
   const handleSortChange = useCallback(async (sort: FeedSortMode) => {
     if (sort === activeSortRef.current) return;
 
+    const requestGeneration = ++requestGenerationRef.current;
     setSelectedSort(sort);
     activeSortRef.current = sort;
     setFeed([]);
@@ -292,16 +295,16 @@ const FeedClient = () => {
     setLoading(true);
     try {
       const data = await getFeedCursor(null, 20, sort);
-      if (activeSortRef.current !== sort) return;
+      if (requestGeneration !== requestGenerationRef.current) return;
       setFeed(data.items);
       setNextCursor(data.nextCursor);
       setHasMore(data.nextCursor != null && data.hasNext);
     } catch (err) {
-      if (activeSortRef.current !== sort) return;
+      if (requestGeneration !== requestGenerationRef.current) return;
       console.error('Error fetching feed:', err);
       setError('initial');
     } finally {
-      if (activeSortRef.current === sort) {
+      if (requestGeneration === requestGenerationRef.current) {
         setLoading(false);
       }
     }

--- a/components/feed/FeedClient.tsx
+++ b/components/feed/FeedClient.tsx
@@ -15,6 +15,7 @@ import { trackEvent, FEED_CLICK, FEED_LIKE } from '@/lib/analytics/events';
 import { getApiErrorMessage } from '@/lib/utils/apiError';
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock';
 import FeedSortSubHeader from './FeedSortSubHeader';
+import FeedSkeleton from './FeedSkeleton';
 import { isAnonymousDiaryIdentity } from '@/lib/utils/privacy';
 
 const FeedClient = () => {
@@ -363,10 +364,10 @@ const FeedClient = () => {
     );
   };
 
-  if (feed.length === 0 && loading) {
+  if (feed.length === 0 && (loading || !hasMounted.current)) {
     return (
-      <div className="flex h-screen items-center justify-center">
-        <p>피드를 불러오는 중...</p>
+      <div className="mx-auto max-w-[600px] pt-[3.75rem] xl:pt-0">
+        <FeedSkeleton count={2} />
       </div>
     );
   }
@@ -409,9 +410,7 @@ const FeedClient = () => {
           </div>
         ))}
         {loading && !isLoadingDetail && (
-          <div className="flex h-20 items-center justify-center">
-            <p>피드를 더 불러오는 중...</p>
-          </div>
+          <FeedSkeleton count={1} />
         )}
       </div>
       {isLoadingDetail && (

--- a/components/feed/FeedClient.tsx
+++ b/components/feed/FeedClient.tsx
@@ -263,7 +263,9 @@ const FeedClient = () => {
       if (loading) return;
       if (observer.current) observer.current.disconnect();
 
+      const observerGeneration = requestGenerationRef.current;
       observer.current = new IntersectionObserver(entries => {
+        if (observerGeneration !== requestGenerationRef.current) return;
         if (entries[0].isIntersecting && hasMore) {
           loadMore();
         }

--- a/components/feed/FeedClient.tsx
+++ b/components/feed/FeedClient.tsx
@@ -364,13 +364,8 @@ const FeedClient = () => {
     );
   };
 
-  if (feed.length === 0 && (loading || !hasMounted.current)) {
-    return (
-      <div className="mx-auto max-w-[600px] pt-[3.75rem] xl:pt-0">
-        <FeedSkeleton count={2} />
-      </div>
-    );
-  }
+  const isInitialLoading =
+    feed.length === 0 && (loading || !hasMounted.current);
 
   if (error === 'initial') {
     return (
@@ -393,24 +388,28 @@ const FeedClient = () => {
         onSortChange={handleSortChange}
       />
       <div className="space-y-8">
-        {feed.map((post, index) => (
-          <div
-            key={post.diaryId}
-            ref={index === feed.length - 1 ? lastPostElementRef : null}
-          >
-            <FeedCard
-              post={post}
-              onFriendshipStatusChange={handleFriendshipStatusChange}
-              onContentClick={() => handleContentClick(post.diaryId)}
-              onCommentClick={() => handleCommentClick(post)}
-              onLikeToggle={handleLikeToggle}
-              onCommentCreated={incrementDiaryCommentCount}
-              isMobile={!isDesktop}
-            />
-          </div>
-        ))}
-        {loading && !isLoadingDetail && (
-          <FeedSkeleton count={1} />
+        {isInitialLoading ? (
+          <FeedSkeleton count={2} />
+        ) : (
+          <>
+            {feed.map((post, index) => (
+              <div
+                key={post.diaryId}
+                ref={index === feed.length - 1 ? lastPostElementRef : null}
+              >
+                <FeedCard
+                  post={post}
+                  onFriendshipStatusChange={handleFriendshipStatusChange}
+                  onContentClick={() => handleContentClick(post.diaryId)}
+                  onCommentClick={() => handleCommentClick(post)}
+                  onLikeToggle={handleLikeToggle}
+                  onCommentCreated={incrementDiaryCommentCount}
+                  isMobile={!isDesktop}
+                />
+              </div>
+            ))}
+            {loading && !isLoadingDetail && <FeedSkeleton count={1} />}
+          </>
         )}
       </div>
       {isLoadingDetail && (

--- a/components/feed/FeedSkeleton.tsx
+++ b/components/feed/FeedSkeleton.tsx
@@ -19,18 +19,17 @@ const FeedSkeletonCard = () => (
     <div className={`aspect-square w-full rounded ${placeholderClassName}`} />
 
     <div className="flex gap-3 p-3">
-      <div className={`h-6 w-14 rounded ${placeholderClassName}`} />
-      <div className={`h-6 w-14 rounded ${placeholderClassName}`} />
+      <div className={`h-7 w-14 rounded ${placeholderClassName}`} />
+      <div className={`h-7 w-14 rounded ${placeholderClassName}`} />
     </div>
 
-    <div className="space-y-2 px-3">
-      <div className={`h-4 w-2/3 rounded ${placeholderClassName}`} />
-      <div className={`h-4 w-5/6 rounded ${placeholderClassName}`} />
+    <div className="px-3">
+      <div className={`h-5 w-5/6 rounded ${placeholderClassName}`} />
     </div>
 
     <div className="mt-2 flex items-center gap-3 border-t border-gray-200 p-3 dark:border-gray-700">
-      <div className={`h-4 flex-1 rounded ${placeholderClassName}`} />
-      <div className={`h-4 w-8 rounded ${placeholderClassName}`} />
+      <div className={`h-5 flex-1 rounded ${placeholderClassName}`} />
+      <div className={`h-5 w-8 rounded ${placeholderClassName}`} />
     </div>
   </div>
 );

--- a/components/feed/FeedSkeleton.tsx
+++ b/components/feed/FeedSkeleton.tsx
@@ -39,7 +39,6 @@ const FeedSkeleton = ({ count }: FeedSkeletonProps) => (
   <div
     role="status"
     aria-label="피드를 불러오는 중"
-    aria-busy="true"
     className="space-y-8"
   >
     <span className="sr-only">피드를 불러오는 중</span>

--- a/components/feed/FeedSkeleton.tsx
+++ b/components/feed/FeedSkeleton.tsx
@@ -1,0 +1,52 @@
+interface FeedSkeletonProps {
+  count: number;
+}
+
+const placeholderClassName = 'bg-gray-200 dark:bg-gray-700';
+
+const FeedSkeletonCard = () => (
+  <div
+    data-testid="feed-skeleton-card"
+    aria-hidden="true"
+    className="w-full rounded-xl border border-gray-200 bg-white p-4 shadow-md motion-safe:animate-pulse dark:border-gray-700 dark:bg-gray-800"
+  >
+    <div className="flex items-center gap-2 p-3">
+      <div className={`h-8 w-8 shrink-0 rounded-full ${placeholderClassName}`} />
+      <div className={`h-3.5 w-24 rounded ${placeholderClassName}`} />
+      <div className={`h-3 w-16 rounded ${placeholderClassName}`} />
+    </div>
+
+    <div className={`aspect-square w-full rounded ${placeholderClassName}`} />
+
+    <div className="flex gap-3 p-3">
+      <div className={`h-6 w-14 rounded ${placeholderClassName}`} />
+      <div className={`h-6 w-14 rounded ${placeholderClassName}`} />
+    </div>
+
+    <div className="space-y-2 px-3">
+      <div className={`h-4 w-2/3 rounded ${placeholderClassName}`} />
+      <div className={`h-4 w-5/6 rounded ${placeholderClassName}`} />
+    </div>
+
+    <div className="mt-2 flex items-center gap-3 border-t border-gray-200 p-3 dark:border-gray-700">
+      <div className={`h-4 flex-1 rounded ${placeholderClassName}`} />
+      <div className={`h-4 w-8 rounded ${placeholderClassName}`} />
+    </div>
+  </div>
+);
+
+const FeedSkeleton = ({ count }: FeedSkeletonProps) => (
+  <div
+    role="status"
+    aria-label="피드를 불러오는 중"
+    aria-busy="true"
+    className="space-y-8"
+  >
+    <span className="sr-only">피드를 불러오는 중</span>
+    {Array.from({ length: count }, (_, index) => (
+      <FeedSkeletonCard key={index} />
+    ))}
+  </div>
+);
+
+export default FeedSkeleton;

--- a/components/feed/__tests__/FeedClient.test.tsx
+++ b/components/feed/__tests__/FeedClient.test.tsx
@@ -411,6 +411,49 @@ describe('FeedClient', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('정렬 변경 전에 등록된 관찰 콜백은 새 정렬의 다음 페이지를 요청하지 않는다', async () => {
+    const recommended = createDeferred<CursorPage<FeedDiary>>();
+    const staleObserverRequest = createDeferred<CursorPage<FeedDiary>>();
+    mockGetFeedCursor
+      .mockResolvedValueOnce(makeResponse([1], 'old-cursor', true))
+      .mockReturnValueOnce(recommended.promise)
+      .mockReturnValueOnce(staleObserverRequest.promise);
+
+    render(<FeedClient />);
+
+    expect(await screen.findByTestId('feed-card-1')).toBeInTheDocument();
+    const oldSortIntersectionCallback = intersectionCallback;
+
+    fireEvent.click(screen.getByRole('button', { name: '추천순' }));
+    await waitFor(() => {
+      expect(mockGetFeedCursor).toHaveBeenNthCalledWith(
+        2,
+        null,
+        20,
+        'recommended',
+      );
+    });
+
+    await act(async () => {
+      oldSortIntersectionCallback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        new MockIntersectionObserver(
+          () => {},
+        ) as unknown as IntersectionObserver,
+      );
+    });
+
+    expect(mockGetFeedCursor).toHaveBeenCalledTimes(2);
+    mockGetFeedCursor.mockReset();
+
+    await act(async () => {
+      recommended.resolve(makeResponse([10], null, false));
+    });
+
+    expect(await screen.findByTestId('feed-card-10')).toBeInTheDocument();
+    expect(screen.queryByTestId('feed-card-1')).not.toBeInTheDocument();
+  });
+
   it('이미 선택된 정렬을 다시 누르면 재요청하지 않고 기존 목록을 유지한다', async () => {
     mockGetFeedCursor.mockResolvedValueOnce(makeResponse([10, 11], 'cursor-latest-1', true));
 

--- a/components/feed/__tests__/FeedClient.test.tsx
+++ b/components/feed/__tests__/FeedClient.test.tsx
@@ -224,6 +224,7 @@ describe('FeedClient', () => {
   it('첫 렌더부터 카드 스켈레톤 2개를 표시한다', () => {
     const markup = renderToStaticMarkup(<FeedClient />);
 
+    expect(markup).toContain('data-testid="feed-sort-subheader"');
     expect(markup.match(/data-testid="feed-skeleton-card"/g) ?? []).toHaveLength(2);
   });
 
@@ -238,6 +239,7 @@ describe('FeedClient', () => {
       name: '피드를 불러오는 중',
     });
 
+    expect(screen.getByTestId('feed-sort-subheader')).toBeInTheDocument();
     expect(
       within(loadingStatus).getAllByTestId('feed-skeleton-card'),
     ).toHaveLength(2);
@@ -322,6 +324,11 @@ describe('FeedClient', () => {
     });
 
     expect(screen.queryByTestId('feed-card-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('feed-sort-subheader')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '추천순' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
     expect(
       within(loadingStatus).getAllByTestId('feed-skeleton-card'),
     ).toHaveLength(2);

--- a/components/feed/__tests__/FeedClient.test.tsx
+++ b/components/feed/__tests__/FeedClient.test.tsx
@@ -218,6 +218,7 @@ const createDeferred = <T,>() => {
 describe('FeedClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetFeedCursor.mockReset();
     mockViewport.isDesktop = true;
     vi.spyOn(window, 'alert').mockImplementation(() => {});
   });
@@ -444,7 +445,6 @@ describe('FeedClient', () => {
     });
 
     expect(mockGetFeedCursor).toHaveBeenCalledTimes(2);
-    mockGetFeedCursor.mockReset();
 
     await act(async () => {
       recommended.resolve(makeResponse([10], null, false));

--- a/components/feed/__tests__/FeedClient.test.tsx
+++ b/components/feed/__tests__/FeedClient.test.tsx
@@ -204,6 +204,17 @@ const makeResponse = (
 
 const createPendingPromise = <T,>() => new Promise<T>(() => {});
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+};
+
 describe('FeedClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -332,6 +343,72 @@ describe('FeedClient', () => {
     expect(
       within(loadingStatus).getAllByTestId('feed-skeleton-card'),
     ).toHaveLength(2);
+  });
+
+  it('같은 정렬로 돌아와도 가장 최근 요청의 결과만 반영한다', async () => {
+    const latestA = createDeferred<CursorPage<FeedDiary>>();
+    const recommendedB = createDeferred<CursorPage<FeedDiary>>();
+    const latestC = createDeferred<CursorPage<FeedDiary>>();
+    mockGetFeedCursor
+      .mockReturnValueOnce(latestA.promise)
+      .mockReturnValueOnce(recommendedB.promise)
+      .mockReturnValueOnce(latestC.promise);
+
+    render(<FeedClient />);
+
+    await waitFor(() => {
+      expect(mockGetFeedCursor).toHaveBeenNthCalledWith(1, null, 20, 'latest');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '추천순' }));
+    await waitFor(() => {
+      expect(mockGetFeedCursor).toHaveBeenNthCalledWith(
+        2,
+        null,
+        20,
+        'recommended',
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '최신순' }));
+    await waitFor(() => {
+      expect(mockGetFeedCursor).toHaveBeenNthCalledWith(3, null, 20, 'latest');
+    });
+
+    await act(async () => {
+      latestA.resolve(makeResponse([1], null, false));
+    });
+
+    let loadingStatus = screen.getByRole('status', {
+      name: '피드를 불러오는 중',
+    });
+    expect(
+      within(loadingStatus).getAllByTestId('feed-skeleton-card'),
+    ).toHaveLength(2);
+    expect(screen.queryAllByTestId(/^feed-card-/)).toHaveLength(0);
+
+    await act(async () => {
+      recommendedB.resolve(makeResponse([2], null, false));
+    });
+
+    loadingStatus = screen.getByRole('status', {
+      name: '피드를 불러오는 중',
+    });
+    expect(
+      within(loadingStatus).getAllByTestId('feed-skeleton-card'),
+    ).toHaveLength(2);
+    expect(screen.queryAllByTestId(/^feed-card-/)).toHaveLength(0);
+
+    await act(async () => {
+      latestC.resolve(makeResponse([3], null, false));
+    });
+
+    expect(await screen.findByTestId('feed-card-3')).toBeInTheDocument();
+    expect(screen.queryByTestId('feed-card-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('feed-card-2')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('status', { name: '피드를 불러오는 중' }),
+    ).not.toBeInTheDocument();
   });
 
   it('이미 선택된 정렬을 다시 누르면 재요청하지 않고 기존 목록을 유지한다', async () => {

--- a/components/feed/__tests__/FeedClient.test.tsx
+++ b/components/feed/__tests__/FeedClient.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, act, fireEvent, within } from '@testing-library/react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import FeedClient from '../FeedClient';
 import { getFeedCursor } from '@/lib/api/feed';
 import { getDiaryById } from '@/lib/api/diary';
@@ -201,6 +202,8 @@ const makeResponse = (
   hasNext,
 });
 
+const createPendingPromise = <T,>() => new Promise<T>(() => {});
+
 describe('FeedClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -216,6 +219,29 @@ describe('FeedClient', () => {
     await waitFor(() => {
       expect(mockGetFeedCursor).toHaveBeenCalledWith(null, 20, 'latest');
     });
+  });
+
+  it('첫 렌더부터 카드 스켈레톤 2개를 표시한다', () => {
+    const markup = renderToStaticMarkup(<FeedClient />);
+
+    expect(markup.match(/data-testid="feed-skeleton-card"/g) ?? []).toHaveLength(2);
+  });
+
+  it('첫 페이지를 불러오는 동안 카드 스켈레톤 2개를 표시한다', async () => {
+    mockGetFeedCursor.mockReturnValue(
+      createPendingPromise<CursorPage<FeedDiary>>(),
+    );
+
+    render(<FeedClient />);
+
+    const loadingStatus = await screen.findByRole('status', {
+      name: '피드를 불러오는 중',
+    });
+
+    expect(
+      within(loadingStatus).getAllByTestId('feed-skeleton-card'),
+    ).toHaveLength(2);
+    expect(screen.queryByText('피드를 불러오는 중...')).not.toBeInTheDocument();
   });
 
   it('피드 아이템을 렌더링한다', async () => {
@@ -273,6 +299,34 @@ describe('FeedClient', () => {
     expect(screen.getByRole('button', { name: '추천순' })).toHaveAttribute('aria-pressed', 'true');
   });
 
+  it('정렬 변경 요청 중에는 이전 목록 대신 카드 스켈레톤 2개를 표시한다', async () => {
+    mockGetFeedCursor.mockResolvedValueOnce(
+      makeResponse([1, 2], 'cursor-latest-1', true),
+    );
+    mockGetFeedCursor.mockReturnValueOnce(
+      createPendingPromise<CursorPage<FeedDiary>>(),
+    );
+
+    render(<FeedClient />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feed-card-1')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '추천순' }));
+    });
+
+    const loadingStatus = await screen.findByRole('status', {
+      name: '피드를 불러오는 중',
+    });
+
+    expect(screen.queryByTestId('feed-card-1')).not.toBeInTheDocument();
+    expect(
+      within(loadingStatus).getAllByTestId('feed-skeleton-card'),
+    ).toHaveLength(2);
+  });
+
   it('이미 선택된 정렬을 다시 누르면 재요청하지 않고 기존 목록을 유지한다', async () => {
     mockGetFeedCursor.mockResolvedValueOnce(makeResponse([10, 11], 'cursor-latest-1', true));
 
@@ -321,6 +375,33 @@ describe('FeedClient', () => {
     const cards = screen.getAllByTestId(/^feed-card-/);
     const ids = cards.map(c => c.getAttribute('data-testid'));
     expect(ids).toEqual(['feed-card-1', 'feed-card-2', 'feed-card-3']);
+  });
+
+  it('다음 페이지를 불러오는 동안 기존 목록 아래에 카드 스켈레톤 1개를 표시한다', async () => {
+    mockGetFeedCursor.mockResolvedValueOnce(
+      makeResponse([1, 2], 'cursor-1', true),
+    );
+    mockGetFeedCursor.mockReturnValueOnce(
+      createPendingPromise<CursorPage<FeedDiary>>(),
+    );
+
+    render(<FeedClient />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feed-card-1')).toBeInTheDocument();
+      expect(screen.getByTestId('feed-card-2')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      intersectionCallback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        new MockIntersectionObserver(() => {}) as unknown as IntersectionObserver,
+      );
+    });
+
+    expect(screen.getByTestId('feed-card-1')).toBeInTheDocument();
+    expect(screen.getByTestId('feed-card-2')).toBeInTheDocument();
+    expect(screen.getAllByTestId('feed-skeleton-card')).toHaveLength(1);
   });
 
   it('hasNext가 false이면 종료 메시지를 표시한다', async () => {

--- a/components/feed/__tests__/FeedSkeleton.test.tsx
+++ b/components/feed/__tests__/FeedSkeleton.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import FeedSkeleton from '../FeedSkeleton';
+
+describe('FeedSkeleton', () => {
+  it('요청한 개수의 장식용 카드를 로딩 상태 안에 표시한다', () => {
+    render(<FeedSkeleton count={2} />);
+
+    const loadingStatus = screen.getByRole('status', {
+      name: '피드를 불러오는 중',
+    });
+    const skeletonCards = within(loadingStatus).getAllByTestId(
+      'feed-skeleton-card',
+    );
+    const assistiveLabel = within(loadingStatus).getByText(
+      '피드를 불러오는 중',
+    );
+
+    expect(skeletonCards).toHaveLength(2);
+    expect(assistiveLabel).toHaveClass('sr-only');
+    skeletonCards.forEach(card => {
+      expect(card).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+});

--- a/components/feed/__tests__/FeedSkeleton.test.tsx
+++ b/components/feed/__tests__/FeedSkeleton.test.tsx
@@ -18,6 +18,7 @@ describe('FeedSkeleton', () => {
 
     expect(skeletonCards).toHaveLength(2);
     expect(assistiveLabel).toHaveClass('sr-only');
+    expect(loadingStatus).not.toHaveAttribute('aria-busy');
     skeletonCards.forEach(card => {
       expect(card).toHaveAttribute('aria-hidden', 'true');
     });

--- a/components/home/HomeRoot.tsx
+++ b/components/home/HomeRoot.tsx
@@ -17,14 +17,10 @@ export default function HomeRoot() {
     setIsLoggedIn(!!token && !!user);
   }, [user]);
 
-  // SSR 시 로딩 상태만 보여주고 클라이언트에서 실제 컴포넌트 렌더링
+  // 클라이언트에서 인증 상태를 확인한 뒤 실제 컴포넌트 렌더링
   if (!isClient) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <p>피드를 불러오는 중...</p>
-      </div>
-    );
+    return null;
   }
 
   return isLoggedIn ? <HomeCalendar /> : <FeedClient />;
-} 
+}

--- a/components/home/__tests__/HomeRoot.test.tsx
+++ b/components/home/__tests__/HomeRoot.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import HomeRoot from '../HomeRoot';
+
+vi.mock('@/components/store/authStore', () => ({
+  default: () => ({ user: null }),
+}));
+
+vi.mock('@/components/home/HomeCalendar', () => ({
+  default: () => <div data-testid="home-calendar" />,
+}));
+
+vi.mock('@/components/feed/FeedClient', () => ({
+  default: () => <div data-testid="feed-client" />,
+}));
+
+describe('HomeRoot', () => {
+  it('인증 확인 전에는 피드 로딩 UI를 표시하지 않는다', () => {
+    const markup = renderToStaticMarkup(<HomeRoot />);
+
+    expect(markup).toBe('');
+    expect(markup).not.toContain('data-testid="feed-skeleton-card"');
+    expect(markup).not.toContain('피드를 불러오는 중...');
+  });
+});

--- a/e2e/feed-skeleton.spec.ts
+++ b/e2e/feed-skeleton.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const mockUser = {
+  id: 'test-user',
+  email: 'tester@example.com',
+  nickname: 'Tester',
+  avatar: '/globe.svg',
+};
+
+const createFeedItem = (diaryId: number) => ({
+  diaryId,
+  status: 'PUBLIC',
+  content: `피드 카드 ${diaryId}`,
+  imgUrls: ['/globe.svg'],
+  date: '2026-07-18',
+  nickname: '익명',
+  avatar: null,
+  userId: null,
+  createdAt: '2026-07-18T12:00:00',
+  commentCount: 0,
+  likeCount: 0,
+  isLiked: false,
+  friendStatus: 'NONE',
+  isOwner: false,
+});
+
+const prepareLoggedInFeed = async (page: Page) => {
+  await page.addInitScript(user => {
+    localStorage.setItem('am', 'test-token');
+    localStorage.setItem(
+      'auth-storage',
+      JSON.stringify({
+        state: {
+          isLoggedIn: true,
+          user,
+        },
+        version: 0,
+      }),
+    );
+  }, mockUser);
+
+  let releaseResponse = () => {};
+  const responseGate = new Promise<void>(resolve => {
+    releaseResponse = resolve;
+  });
+
+  await page.route('**/api/diary**', async route => {
+    await responseGate;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: [createFeedItem(1), createFeedItem(2)],
+        nextCursor: null,
+        hasNext: false,
+      }),
+    });
+  });
+
+  return releaseResponse;
+};
+
+for (const testCase of [
+  { name: '데스크톱', viewport: { width: 1280, height: 900 } },
+  { name: '모바일', viewport: { width: 390, height: 844 } },
+]) {
+  test(`로그인 사용자의 ${testCase.name} 피드에서 스켈레톤과 실제 카드 크기가 같다`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(testCase.viewport);
+    const releaseResponse = await prepareLoggedInFeed(page);
+
+    await page.goto('/feed');
+    await expect(page.getByTestId('feed-sort-subheader')).toBeVisible();
+
+    const skeletons = page.getByTestId('feed-skeleton-card');
+    await expect(skeletons).toHaveCount(2);
+    const skeleton = skeletons.first();
+    await expect(skeleton).toBeVisible();
+    const skeletonBox = await skeleton.boundingBox();
+    expect(skeletonBox).not.toBeNull();
+
+    releaseResponse();
+
+    const feedCard = page.getByTestId('feed-card').first();
+    await expect(feedCard).toBeVisible();
+    await expect(skeletons).toHaveCount(0);
+    const feedCardBox = await feedCard.boundingBox();
+    expect(feedCardBox).not.toBeNull();
+
+    expect(feedCardBox!.width).toBeCloseTo(skeletonBox!.width, 1);
+    expect(feedCardBox!.height).toBeCloseTo(skeletonBox!.height, 1);
+  });
+}


### PR DESCRIPTION
- 피드 초기 로딩과 추가 페이지 로딩에 카드 형태의 스켈레톤 UI 적용
- 로그인 여부와 관계없이 피드 데이터 응답 전 스켈레톤 표시
- 기존 `피드를 불러오는 중...` 텍스트 로딩 UI 제거
- 정렬 전환 시 이전 요청 결과와 오래된 IntersectionObserver 콜백 무효화
- 스켈레톤을 실제 피드 카드와 동일한 크기로 조정
- 데스크톱·모바일에서 스켈레톤과 실제 카드 크기를 비교하는 E2E 테스트 추가